### PR TITLE
feat: set bundle.js/css file names to static names so that dev tool panel builds are dynamic

### DIFF
--- a/devtools/devtools.html
+++ b/devtools/devtools.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="dist/assets/index-CxN9Fy7r.css" />
+    <link rel="stylesheet" href="dist/bundle.css" />
     <title>Document</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="dist/assets/index-C330SAyt.js"></script>
+    <script type="module" src="dist/bundle.js"></script>
     <script src="devtools.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/chrome": "^0.0.263",
+        "@types/node": "^20.11.27",
+        "rollup": "^4.13.0",
         "svelte-splitpanes": "^0.8.0"
       },
       "devDependencies": {
@@ -486,7 +488,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -499,7 +500,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -512,7 +512,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -525,7 +524,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -538,7 +536,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -551,7 +548,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -564,7 +560,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -577,7 +572,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -590,7 +584,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -603,7 +596,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -616,7 +608,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -629,7 +620,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -642,7 +632,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -724,6 +713,14 @@
       "version": "1.2.15",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
       "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
+      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -1035,7 +1032,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1454,7 +1450,6 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
       "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -1726,6 +1721,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/vite": {
       "version": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@types/chrome": "^0.0.263",
+    "@types/node": "^20.11.27",
+    "rollup": "^4.13.0",
     "svelte-splitpanes": "^0.8.0"
   }
 }

--- a/src/lib/SplitpaneContainer.svelte
+++ b/src/lib/SplitpaneContainer.svelte
@@ -5,12 +5,12 @@
 <Splitpanes style="height: 100%">
   <Pane size={50} minSize={20}>
     <div class="pane">
-      <p>selector</p>
+      <p>left pane</p>
     </div>
   </Pane>
   <Pane size={50} minSize={20}>
     <div class="pane">
-      <p>editor</p>
+      <p>right pane</p>
     </div>
   </Pane>
 </Splitpanes>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 export default defineConfig({
   plugins: [svelte()],
   build: {
-    outDir: './devtools/dist'
+    outDir: './devtools/dist',
+    rollupOptions: {
+      output: {
+        entryFileNames: 'bundle.js',
+        assetFileNames: 'bundle.css'
+      }
+    }
   }
 })


### PR DESCRIPTION
set bundle.js/css file names to static names so that dev tool panel builds are dynamic

## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've followed the [Contributing guidelines](https://github.com/community-health-demo/.github/blob/main/CONTRIBUTING.md)
- [ ] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've linked an open issue
- [ ] I've added tests that fail without this PR but pass with it
- [ ] I've linted and tested my code
- [ ] I've updated documentation (if appropriate)